### PR TITLE
Fix WSL gitconfig instructions in second blog post

### DIFF
--- a/_posts/2025-04-02-looks-like-a-duck.md
+++ b/_posts/2025-04-02-looks-like-a-duck.md
@@ -51,7 +51,9 @@ P4Merge is a visual diff and merge tool which can be configured for git accordin
 [mergetool]
         keepBackup = false
 [mergetool "p4merge"]
-        cmd = p4merge.exe \"$BASE\" \"$LOCAL\" \"$REMOTE\" \"$MERGED\"
+        cmd = p4merge.exe \"$(wslpath -aw $BASE)\" \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\" \"$(wslpath -aw $MERGED)\"
+[difftool "p4merge"]
+        cmd = p4merge.exe \"$(wslpath -aw $LOCAL)\" \"$(wslpath -aw $REMOTE)\"
 [commit]
         gpgsign = true
 [tag]


### PR DESCRIPTION
This PR corrects a mistake in the second blog post regarding the WSL gitconfig configuration. It updates the p4merge commands to correctly wrap paths with wslpath -aw so that the Windows p4merge.exe GUI client can resolve and display files correctly when called from WSL.