### PR TITLE
Fix: workflow refs passing boolean as git ref

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'release'
+        description: 'Deploy to production (confirm)'
         required: true
-        type: string
+        type: boolean
 permissions:
   contents: read
   pages: write
@@ -16,7 +16,7 @@ jobs:
     needs: relase-info
     uses: ./.github/workflows/pipeline.yml
     with:
-      refs: ${{ inputs.release }}
+      refs: main
       code-directory: /
       environmnet: production
       site-prefix: www


### PR DESCRIPTION
The refs input in pipeline.yml was being set to the release boolean (true/false) instead of a branch name. This caused checkout to attempt fetching refs/heads/true* which does not exist. Fix: hardcode refs=main in production.yml since production always deploys main.