### PR TITLE
Fix: restore release tag ref pattern

### DIFF
--- a/.github/workflows/production.yml
+++ b/.github/workflows/production.yml
@@ -3,9 +3,9 @@ on:
   workflow_dispatch:
     inputs:
       release:
-        description: 'Deploy to production (confirm)'
+        description: 'Release tag to deploy (e.g. 0.0.8). Create a tag + GitHub Release first, then pass the tag name here.'
         required: true
-        type: boolean
+        type: string
 permissions:
   contents: read
   pages: write
@@ -16,7 +16,7 @@ jobs:
     needs: relase-info
     uses: ./.github/workflows/pipeline.yml
     with:
-      refs: main
+      refs: ${{ inputs.release }}
       code-directory: /
       environmnet: production
       site-prefix: www


### PR DESCRIPTION
PR #7 incorrectly changed the release input to a boolean and hardcoded refs=main, breaking the intended tag-based release flow. This restores: release as a string (the tag name e.g. 0.0.8), passed through as refs to the pipeline checkout. Usage: create a tag and GitHub Release first, then invoke the workflow with the tag name.